### PR TITLE
Change the link to redirect to new skills page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Merge conflicts happen when two people make changes to the same file on GitHubâ€
 - **Who is this for**: New developers, new GitHub users, users new to Git, students, managers, teams.
 - **What you'll learn**: What merge conflicts are, how you resolve merge conflicts, how to reduce merge conflicts.
 - **What you'll build**: We'll work with a short Markdown resume file in this course.
-- **Prerequisites**: We recommend taking [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github) prior to this course.
+- **Prerequisites**: We recommend taking [Introduction to GitHub](https://github.com/skills/introduction-to-github) prior to this course.
 - **How long**: This course is three steps long and takes less than 30 minutes to complete.
 
 ## How to start this course


### PR DESCRIPTION
### Why:

A link in README.md redirects to GitHub Learning Lab.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
The link now redirects to GitHub Skills Introduction to GitHub repository.
lab.github.com/githubtraining/ &rarr; github.com/skills/
Cf. [similar PR](https://github.com/skills/publish-packages/pull/5)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
