### PR TITLE
chore: bump exercise-toolkit version to v0.9.3

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.9.3
     with:
       exercise-title: "Resolve Merge Conflicts"
       intro-message: "Let's learn how to resolve merge conflicts when collaborating on GitHub."
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.7.0
+          ref: v0.9.3
 
       - name: Create comment - add step content
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   post_next_step_content:
     name: Post next step content
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.7.0
+          ref: v0.9.3
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   post_next_step_content:
     name: Post next step content
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.7.0
+          ref: v0.9.3
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.pull_request.merged == true &&
       github.head_ref == 'my-resume'
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.9.3
 
   post_review_content:
     name: Post review content
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.7.0
+          ref: v0.9.3
 
       - name: Create comment - add review content
         uses: GrantBirki/comment@v2.1.1
@@ -57,6 +57,6 @@ jobs:
   finish_exercise:
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
-    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}


### PR DESCRIPTION
### Summary

Bump `exercise-toolkit` to `v0.9.3` to fix a formatting bug in the final completion message.

### Changes
<!-- Describe the changes this pull request introduces. -->
Updated the `exercise-toolkit` version reference from `v0.7.0` to `v0.9.3` in all GitHub Actions workflows (`0-step.yml` to `3-step.yml`). 

This update pulls in the fix introduced in `exercise-toolkit` v0.7.1 (PR #85) which removes the extra parenthesis `))` at the end of the "Explore GitHub Skills" link generated in the final `README.md`.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected (check this test repository: https://github.com/b4ssem/resolve-merge-conflicts-test 
Runs perfectly and the review `README.MD` doesn't contain the extra parenthesis anymore.)
- [ ] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide). **(Not applicable)**